### PR TITLE
feat: Add swagger

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
                 "@nestjs/jwt": "^9.0.0",
                 "@nestjs/passport": "^9.0.0",
                 "@nestjs/platform-express": "^8.0.0",
+                "@nestjs/swagger": "^5.2.1",
                 "@nestjs/typeorm": "^9.0.0",
                 "@types/bcrypt": "^5.0.0",
                 "aws-sdk": "^2.1208.0",
@@ -2861,6 +2862,25 @@
                 "@nestjs/common": "^8.0.0 || ^9.0.0"
             }
         },
+        "node_modules/@nestjs/mapped-types": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-1.0.1.tgz",
+            "integrity": "sha512-NFvofzSinp00j5rzUd4tf+xi9od6383iY0JP7o0Bnu1fuItAUkWBgc4EKuIQ3D+c2QI3i9pG1kDWAeY27EMGtg==",
+            "peerDependencies": {
+                "@nestjs/common": "^7.0.8 || ^8.0.0",
+                "class-transformer": "^0.2.0 || ^0.3.0 || ^0.4.0 || ^0.5.0",
+                "class-validator": "^0.11.1 || ^0.12.0 || ^0.13.0",
+                "reflect-metadata": "^0.1.12"
+            },
+            "peerDependenciesMeta": {
+                "class-transformer": {
+                    "optional": true
+                },
+                "class-validator": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@nestjs/passport": {
             "version": "9.0.0",
             "resolved": "https://registry.npmjs.org/@nestjs/passport/-/passport-9.0.0.tgz",
@@ -2985,6 +3005,31 @@
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
             "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
             "dev": true
+        },
+        "node_modules/@nestjs/swagger": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-5.2.1.tgz",
+            "integrity": "sha512-7dNa08WCnTsW/oAk3Ujde+z64JMfNm19DhpXasFR8oJp/9pggYAbYU927HpA+GJsSFJX6adjIRZsCKUqaGWznw==",
+            "dependencies": {
+                "@nestjs/mapped-types": "1.0.1",
+                "lodash": "4.17.21",
+                "path-to-regexp": "3.2.0"
+            },
+            "peerDependencies": {
+                "@nestjs/common": "^8.0.0",
+                "@nestjs/core": "^8.0.0",
+                "fastify-swagger": "*",
+                "reflect-metadata": "^0.1.12",
+                "swagger-ui-express": "*"
+            },
+            "peerDependenciesMeta": {
+                "fastify-swagger": {
+                    "optional": true
+                },
+                "swagger-ui-express": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/@nestjs/testing": {
             "version": "8.4.7",
@@ -13983,6 +14028,12 @@
                 "jsonwebtoken": "8.5.1"
             }
         },
+        "@nestjs/mapped-types": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-1.0.1.tgz",
+            "integrity": "sha512-NFvofzSinp00j5rzUd4tf+xi9od6383iY0JP7o0Bnu1fuItAUkWBgc4EKuIQ3D+c2QI3i9pG1kDWAeY27EMGtg==",
+            "requires": {}
+        },
         "@nestjs/passport": {
             "version": "9.0.0",
             "resolved": "https://registry.npmjs.org/@nestjs/passport/-/passport-9.0.0.tgz",
@@ -14072,6 +14123,16 @@
                     "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
                     "dev": true
                 }
+            }
+        },
+        "@nestjs/swagger": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-5.2.1.tgz",
+            "integrity": "sha512-7dNa08WCnTsW/oAk3Ujde+z64JMfNm19DhpXasFR8oJp/9pggYAbYU927HpA+GJsSFJX6adjIRZsCKUqaGWznw==",
+            "requires": {
+                "@nestjs/mapped-types": "1.0.1",
+                "lodash": "4.17.21",
+                "path-to-regexp": "3.2.0"
             }
         },
         "@nestjs/testing": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
         "@nestjs/jwt": "^9.0.0",
         "@nestjs/passport": "^9.0.0",
         "@nestjs/platform-express": "^8.0.0",
+        "@nestjs/swagger": "^5.2.1",
         "@nestjs/typeorm": "^9.0.0",
         "@types/bcrypt": "^5.0.0",
         "aws-sdk": "^2.1208.0",

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -3,9 +3,20 @@ import { NestExpressApplication } from '@nestjs/platform-express';
 import * as cookieParser from 'cookie-parser';
 import { AppModule } from '@/AppModule';
 import { ValidationPipe } from '@nestjs/common';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 
 export const bootstrap = async (): Promise<NestExpressApplication> => {
     const app = await NestFactory.create<NestExpressApplication>(AppModule);
+
+    const config = new DocumentBuilder()
+        .setTitle('Momentrip API Docs')
+        .setDescription('Momentrip API Docs')
+        .setVersion('1.0')
+        .build();
+
+    const document = SwaggerModule.createDocument(app, config);
+
+    SwaggerModule.setup('docs', app, document);
 
     app.disable('x-powered-by');
 


### PR DESCRIPTION
- API Docs의 역할을 하는 Swagger 추가

## 사용법

1. `npm i` 명령을 통해 패키지 설치
2. `npm run start` 또는 `npm run start:dev` 명령을 통해 서버 실행
3. 서버 URL의 path에 /docs 로 접근할 경우, API Docs를 확인할 수 있음